### PR TITLE
Bugfix: undefined object 'queue' instead of 'query' will cause a crash if if self.rotary_dim > self.head_dim.

### DIFF
--- a/src/transformers/models/gpt_neo/modeling_gpt_neo.py
+++ b/src/transformers/models/gpt_neo/modeling_gpt_neo.py
@@ -328,7 +328,7 @@ class GPTNeoSelfAttention(nn.Module, GPTNeoAttentionMixin):
                 query = torch.cat([q_rot, q_pass], dim=-1)
             elif self.rotary:
                 key = apply_rotary_pos_emb(key, (self.sin, self.cos), offset=offset).to(key.dtype)
-                query = apply_rotary_pos_emb(query, (self.sin, self.cos), offset=offset).to(queue.dtype)
+                query = apply_rotary_pos_emb(query, (self.sin, self.cos), offset=offset).to(query.dtype)
             key = key.permute(0, 2, 1, 3)
             query = query.permute(0, 2, 1, 3)
 


### PR DESCRIPTION
# What does this PR do?
GPT Base refers to a nonexistent object 'queue' instead of query when performing rotary operations.  This will cause a crash under certain circumstances.

Please forgive the hastily written commit message -- the patch is quite small and I'm in a hurry.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

It's basically a typo, but causes a crash.