### PR TITLE
Load split models from huggingface's cache

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -286,6 +286,8 @@ class PretrainedConfig(PushToHubMixin):
 
         # Name or path to the pretrained checkpoint
         self._name_or_path = str(kwargs.pop("name_or_path", ""))
+        self.subfolder = kwargs.pop("subfolder", None)
+        self.is_split = kwargs.pop("is_split", None)
 
         # Drop the transformers version info
         self.transformers_version = kwargs.pop("transformers_version", None)
@@ -390,6 +392,9 @@ class PretrainedConfig(PushToHubMixin):
                 The specific model version to use. It can be a branch name, a tag name, or a commit id, since we use a
                 git-based system for storing models and other artifacts on huggingface.co, so ``revision`` can be any
                 identifier allowed by git.
+            subfolder (:obj:`str`, `optional`):
+                In case the relevant files are located inside a subfolder of the model repo on huggingface.co (e.g. for
+                facebook/rag-token-base), specify it here.
             return_unused_kwargs (:obj:`bool`, `optional`, defaults to :obj:`False`):
                 If :obj:`False`, then this function returns just the final configuration object.
 
@@ -458,6 +463,7 @@ class PretrainedConfig(PushToHubMixin):
         use_auth_token = kwargs.pop("use_auth_token", None)
         local_files_only = kwargs.pop("local_files_only", False)
         revision = kwargs.pop("revision", None)
+        subfolder = kwargs.pop("subfolder", None)
         from_pipeline = kwargs.pop("_from_pipeline", None)
         from_auto_class = kwargs.pop("_from_auto", False)
 
@@ -476,7 +482,7 @@ class PretrainedConfig(PushToHubMixin):
             config_file = pretrained_model_name_or_path
         else:
             config_file = hf_bucket_url(
-                pretrained_model_name_or_path, filename=CONFIG_NAME, revision=revision, mirror=None
+                pretrained_model_name_or_path, filename=CONFIG_NAME, revision=revision, subfolder=subfolder, mirror=None
             )
 
         try:

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -148,6 +148,8 @@ class PretrainedConfig(PushToHubMixin):
         - **remove_invalid_values** (:obj:`bool`, `optional`) -- Whether to remove possible `nan` and `inf` outputs of
           the model to prevent the generation method to crash. Note that using ``remove_invalid_values`` can slow down
           generation.
+        - **subfolder** (:obj:`str`, `optional`, defaults to :obj:`None`) -- In case the model files are located
+          inside a further subfolder relative to the config.json file (e.g. for NovelAI/genji-python-6B-split).
 
 
     Parameters for fine-tuning tasks
@@ -192,6 +194,7 @@ class PretrainedConfig(PushToHubMixin):
         - **tie_word_embeddings** (:obj:`bool`, `optional`, defaults to :obj:`True`) -- Whether the model's input and
           output word embeddings should be tied. Note that this is only relevant if the model has a output word
           embedding layer.
+        - **is_split** (:obj:`bool`, `optional`, defaults to :obj:`False`) -- Whether the model is stored in split format (m.pt and b*.pt)
 
     TensorFlow specific parameters
 

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -1127,6 +1127,10 @@ def hf_bucket_url(
     """
     if subfolder is not None:
         filename = f"{subfolder}/{filename}"
+    if model_id.count('/') > 1:
+        model_org, model_name, subfolder = model_id.split('/', 2)
+        model_id = f"{model_org}/{model_name}"
+        filename = f"{subfolder}/{filename}"
 
     if mirror:
         endpoint = PRESET_MIRROR_DICT.get(mirror, mirror)

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -381,7 +381,7 @@ def pipeline(
 
     # Infer the framework form the model
     if framework is None:
-        framework, model = infer_framework_from_model(model, targeted_task, revision=revision, task=task)
+        framework, model = infer_framework_from_model(model, targeted_task, revision=revision, task=task, **model_kwargs)
 
     task_class, model_class = targeted_task["impl"], targeted_task[framework]
 


### PR DESCRIPTION
There might be some other fixes (or latent bugs) that crept in here too, as I'm somewhat groggy.

This is an attempt to add hugging face cache support to the concept of loading split models.

With this addition, the following works.
```
pygen = transformers.pipeline('text-generation', 'NovelAI/genji-python-6B-split/model', tokenizer='EleutherAI/gpt-neo-2.7B', device=0)

print(pygen('def print_hello_world_literal('))
```

It relies on a fudge that detects '-split' in the model name to load it as split.  Alternatively, `"is_split": true` and `"subfolder": "model" ` can now be set in the model configuration to specify those parameters directly.