### PR TITLE
Add missing module __spec__ fix from upstream

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -2645,7 +2645,7 @@ else:
                 return __version__
             return super().__getattr__(name)
 
-    sys.modules[__name__] = _LazyModule(__name__, module_spec=__spec__, _import_structure)
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure, module_spec=__spec__,)
 
 
 if not is_tf_available() and not is_torch_available() and not is_flax_available():

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -2645,7 +2645,7 @@ else:
                 return __version__
             return super().__getattr__(name)
 
-    sys.modules[__name__] = _LazyModule(__name__, _import_structure)
+    sys.modules[__name__] = _LazyModule(__name__, module_spec=__spec__, _import_structure)
 
 
 if not is_tf_available() and not is_torch_available() and not is_flax_available():

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -1799,7 +1799,7 @@ class _BaseLazyModule(ModuleType):
 
     # Very heavily inspired by optuna.integration._IntegrationModule
     # https://github.com/optuna/optuna/blob/master/optuna/integration/__init__.py
-    def __init__(self, name, import_structure):
+    def __init__(self, name, module_spec=None, import_structure):
         super().__init__(name)
         self._modules = set(import_structure.keys())
         self._class_to_module = {}
@@ -1808,6 +1808,7 @@ class _BaseLazyModule(ModuleType):
                 self._class_to_module[value] = key
         # Needed for autocompletion in an IDE
         self.__all__ = list(import_structure.keys()) + sum(import_structure.values(), [])
+        self.__spec__ = module_spec
 
     # Needed for autocompletion in an IDE
     def __dir__(self):

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -1799,7 +1799,7 @@ class _BaseLazyModule(ModuleType):
 
     # Very heavily inspired by optuna.integration._IntegrationModule
     # https://github.com/optuna/optuna/blob/master/optuna/integration/__init__.py
-    def __init__(self, name, module_spec=None, import_structure):
+    def __init__(self, name, import_structure, module_spec=None,):
         super().__init__(name)
         self._modules = set(import_structure.keys())
         self._class_to_module = {}

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import unittest
 
 import requests
+import transformers
 
 # Try to import everything from transformers to ensure every object can be loaded.
 from transformers import *  # noqa F406
@@ -36,6 +38,11 @@ PINNED_SHA1 = "d9e9f15bc825e4b2c9249e9578f884bbcb5e3684"
 # Sha-1 of config.json on the top of `main`, for checking purposes
 PINNED_SHA256 = "4b243c475af8d0a7754e87d7d096c92e5199ec2fe168a2ee7998e3b8e9bcb1d3"
 # Sha-256 of pytorch_model.bin on the top of `main`, for checking purposes
+
+
+def test_module_spec():
+    assert transformers.__spec__ is not None
+    assert importlib.util.find_spec("transformers") is not None
 
 
 class GetFromCacheTests(unittest.TestCase):


### PR DESCRIPTION
This PR fixes compatibility with packages like aitextgen. It pulls the fixes from https://github.com/huggingface/transformers/pull/13321 into this fork.